### PR TITLE
Fix deprecated parameter - do_exit

### DIFF
--- a/precommit-pylint.py
+++ b/precommit-pylint.py
@@ -46,7 +46,7 @@ def check_file(limit, filename, output=False):
     buffer = io.StringIO()
     with contextlib.redirect_stdout(buffer):
         with contextlib.redirect_stderr(buffer):
-            linter = pylint_run([filename], do_exit=False).linter
+            linter = pylint_run([filename], exit=False).linter
 
     out = buffer.getvalue()
 


### PR DESCRIPTION
`do_exit` parameter in the Run pylint class is deprecated and has been removed since version 3.0.0. It is replaced by `exit`.